### PR TITLE
Add ext-openssl to requirement section of composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "php": "~7.1",
         "react/promise": "^2.7"
     },
+    "suggest": {
+        "ext-openssl": "to able SSL socket streams usage"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "0.11.x-dev"


### PR DESCRIPTION
As I can see, you use openssl extension in \Alpari\Kafka\Stream\SocketStream::encryptChannel, but it is not required in composer.json